### PR TITLE
Make setup script to support more options when creating python virtual environments

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# make sure uv is installed, if not: 
+# make sure uv is installed, if not:
 # curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # for MacOS users:
@@ -24,13 +24,13 @@ if [ "$MINIMAL" = true ]; then
     echo "Installing minimal dependencies [Erwin]"
     uv pip install torch==2.5.0
     uv pip install torch-cluster -f https://data.pyg.org/whl/torch-2.5.0+cu124.html # CUDA 12.4
-    uv pip install numpy 
+    uv pip install numpy
     uv pip install einops
-    
+
     if [ "$W_FLASH_ATTN" = true ]; then
         uv pip install flash-attn
     fi
-    
+
     uv pip install balltree-erwin
 else
     echo "Installing all dependencies [Erwin + baselines + experiments]"
@@ -38,13 +38,13 @@ else
     # Erwin dependencies
     uv pip install torch==2.5.0
     uv pip install torch-cluster -f https://data.pyg.org/whl/torch-2.5.0+cu124.html # CUDA 12.4
-    uv pip install numpy 
+    uv pip install numpy
     uv pip install einops
-    
+
     if [ "$W_FLASH_ATTN" = true ]; then
         uv pip install flash-attn
     fi
-    
+
     uv pip install balltree-erwin
 
     # PointTransformer v3 dependencies

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,8 @@
 # for MacOS users:
 # brew install libomp
 
+set -e
+
 uv venv erwin --python 3.9
 source erwin/bin/activate
 

--- a/setup.sh
+++ b/setup.sh
@@ -8,19 +8,44 @@
 
 set -e
 
-uv venv erwin --python 3.9
-source erwin/bin/activate
-
 MINIMAL=false
 W_FLASH_ATTN=false
+VENV_PATH="./erwin"
+PYTHON_BIN_PATH=$(which python)
 
-if [[ "$*" == *"--minimal"* ]]; then
-    MINIMAL=true
-fi
 
-if [[ "$*" == *"--with-flash-attn"* ]]; then
-    W_FLASH_ATTN=true
-fi
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --minimal)
+            MINIMAL=true
+            shift
+            ;;
+        --with-flash-attn)
+            W_FLASH_ATTN=true
+            shift
+            ;;
+        --venv)
+            VENV_PATH="$2"
+            shift 2
+            ;;
+        --python)
+            PYTHON_BIN_PATH="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Usage: $0 [--venv VENV_PATH] [--minimal]"
+            exit 1
+            ;;
+    esac
+done
+
+
+# create and check in the target python virtual environment
+uv venv "${VENV_PATH}" --python "${PYTHON_BIN_PATH}"
+source "${VENV_PATH}/bin/activate"
+
 
 if [ "$MINIMAL" = true ]; then
     echo "Installing minimal dependencies [Erwin]"


### PR DESCRIPTION
# Description

By landing this pull request, the setup script can begin to create python virtual environments more freely, e.g. python interpreter versions and the path of target virtual environment.

# How to Test This Pull Request

```
bash ./setup.sh --venv ../erwin-venv --python <where your python bin locates>
```

I tested the above command by assigning my self-built cpython 3.11.